### PR TITLE
Remove `pip` cache configuration from test workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
 
       - name: Install uv (official method)
         run: |


### PR DESCRIPTION
This pull request removes the `pip` cache configuration from the test workflow. The change simplifies configuration as caching for `pip` is redundant in the current setup. No additional modifications or features are introduced.