### PR TITLE
Add uv sync command example for dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ Install the package (editable mode):
 
 ```bash
 python -m pip install -e .
+
+# Install project dependencies with uv (if you use uv to manage dependencies)
+uv sync
 ```
 
-Dependencies are declared in pyproject.toml. If you use `uv` to manage dependencies, use it to sync/install per the pyproject configuration (dev dependencies live under `[dependency-groups]`).
+
+Dependencies are declared in pyproject.toml. If you use `uv` to manage dependencies, use it to sync/install per the pyproject configuration.
 
 Run tests:
 


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to clarify how to install project dependencies when using `uv` as a dependency manager.

Installation instructions update:

* Added a step to run `uv sync` after installing the package in editable mode, specifically for users managing dependencies with `uv`.
* Clarified the explanation about dependency declaration in `pyproject.toml` and simplified the guidance for syncing/installing dependencies with `uv`.